### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,3 +731,4 @@ This repository contains a curated list of awesome open source libraries that wi
 * [Weights & Biases](https://github.com/wandb/wandb) ![](https://img.shields.io/github/stars/wandb/wandb.svg?style=social) - Machine learning experiment tracking, dataset versioning, hyperparameter search, visualization, and collaboration.
 * [WhyLabs](https://whylabs.ai/) - Enable observability to detect data and ML issues faster, deliver continuous improvements, and avoid costly incidents.
 * [Zilliz](https://zilliz.com/) - Zilliz builds vector database to accelerate development of next generation data fabric.
+* [mlinfra](https://mlinfra.io/) - mlinfra aims to make MLOps infrastructure deployment easy and accessible to all ML teams. It does so by abstracting away deployment logic for all tools under one tool which makes it one click deployment solution for ml infrastructure.


### PR DESCRIPTION
- [mlinfra](https://mlinfra.io/) aims to help users deploy mlops server side tools faster and in a standardised way.
- It provides an easy convenient way to describe the infrastructure stack and leverages the combination of python and terraform to deploy that stack.